### PR TITLE
Fix safari softlock

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -415,7 +415,7 @@
 @import "achievementsModal.html"
 
 <!-- Oak Items Modal-->
-@import "OakItemsModal.html"
+@import "oakItemsModal.html"
 
 <!-- Statistics Modal-->
 @import "statisticsModal.html"

--- a/src/scripts/safari/SafariBattle.ts
+++ b/src/scripts/safari/SafariBattle.ts
@@ -242,9 +242,10 @@ class SafariBattle {
     }
 
     private static endBattle() {
-        Safari.inBattle(false);
-        SafariBattle.busy = false;
-        $('#safariBattleModal').modal('hide');
+        $('#safariBattleModal').one('hidden.bs.modal', () => {
+            Safari.inBattle(false);
+            SafariBattle.busy = false;
+        }).modal('hide');
     }
 
     private static gameOver() {


### PR DESCRIPTION
To reproduce the safari soft lock on develop,
1. get into a safari battle
2. click run
3. start spamming a directional key into grass
If you are lucky and fast enough, you can get an encounter on the first grass tile before the safariBattleModal has finished hiding. This puts you in a broken in-between state.

Unrelated oakItemsModal fix is because gulp refused to compile the project until I dealt with the missing file it was complaining about.