### PR TITLE
Allow filtering pokedex by pure types

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -30,14 +30,14 @@ aria-labelledby="pokedexModalLabel">
                            <div class="col-5">
                                <select id="pokedex-filter-type1" class="custom-select"
                                        oninput="PokedexHelper.updateList()" style="margin-right: 8px">
-                                   <option value="-1" selected>All</option>
+                                   <option value="" selected>All</option>
                                </select>
                            </div>
                            <label class="sr-only" for="pokedex-filter-type2">Type</label>
                            <div class="col-5">
                                <select id="pokedex-filter-type2" class="custom-select"
                                        oninput="PokedexHelper.updateList()">
-                                   <option value="-1" selected>All</option>
+                                   <option value="" selected>All</option>
                                </select>
                            </div>
                        </div>

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -75,9 +75,14 @@ class PokedexHelper {
             }
 
             // Check if either of the types match
-            const type1: PokemonType = parseInt(filter['type1'] || PokemonType.None);
-            const type2: PokemonType = parseInt(filter['type2'] || PokemonType.None);
-            if ((type1 != PokemonType.None && !pokemon.type.includes(type1)) || (type2 != PokemonType.None && !pokemon.type.includes(type2))) {
+            const type1: (PokemonType | null) = filter['type1'] ? parseInt(filter['type1']) : null;
+            const type2: (PokemonType | null) = filter['type2'] ? parseInt(filter['type2']) : null;
+            if ([type1, type2].includes(PokemonType.None)) {
+                const type = (type1 == PokemonType.None) ? type2 : type1;
+                if (!PokedexHelper.isPureType(pokemon, type)) {
+                    return false;
+                }
+            } else if ((type1 != null && !pokemon.type.includes(type1)) || (type2 != null && !pokemon.type.includes(type2))) {
                 return false;
             }
 
@@ -130,5 +135,9 @@ class PokedexHelper {
         }
         src += `pokemon/${id}.png`;
         return src;
+    }
+
+    private static isPureType(pokemon: PokemonListData, type: (PokemonType | null)): boolean {
+        return (pokemon.type.length === 1 && (type == null || pokemon.type[0] === type));
     }
 }

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -8,29 +8,31 @@
 
 const pokemonDevolutionMap: { [name: string]: string } = {};
 
+type PokemonListData = {
+  id: number;
+  name: string;
+  catchRate: number;
+  evolutions?: Evolution[];
+  type: PokemonType[];
+  base: {
+    hitpoints: number;
+    attack: number;
+    specialAttack: number;
+    defense: number;
+    specialDefense: number;
+    speed: number;
+  };
+  levelType: LevelType;
+  exp: number;
+  eggCycles: number;
+  baby?: boolean;
+  attack?: number;
+}
+
 /**
  * Datalist that contains all Pokémon data
  */
-const pokemonList: {
-    id: number;
-    name: string;
-    catchRate: number;
-    evolutions?: Evolution[];
-    type: PokemonType[];
-    base: {
-        hitpoints: number;
-        attack: number;
-        specialAttack: number;
-        defense: number;
-        specialDefense: number;
-        speed: number;
-    };
-    levelType: LevelType;
-    exp: number;
-    eggCycles: number;
-    baby?: boolean;
-    attack?: number;
-}[] =
+const pokemonList: PokemonListData[] =
     [
         {
             'id': 1,


### PR DESCRIPTION
Choosing a type filter of `None` now means "Only show me pokemon that are purely whatever type the other filter says"

All/Type continues to show both pure and mixed type containing Type
All/None shows only pure types, of any type