### PR TITLE
Make modal footer always visible when viewing on smaller screens

### DIFF
--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -496,3 +496,11 @@ td.tight {
 .all-pointers {
   pointer-events: all !important;
 }
+
+/* Modal body scrollable on smaller screens */
+@media (max-width: 575px) {
+  .modal-body {
+    max-height: calc(100vh - 160px);
+    overflow: auto;
+  }
+}


### PR DESCRIPTION
Helps with closing modals on mobile,

Make modal footers always visible when viewing on smaller screens
![image](https://user-images.githubusercontent.com/7288322/89117114-48b03080-d4ef-11ea-9816-74bb008094ad.png)
