### PR TITLE
Give event Pokemon a native region, Fix event evolutions

### DIFF
--- a/src/components/shipModal.html
+++ b/src/components/shipModal.html
@@ -10,6 +10,7 @@
             <div class="modal-body bg-ocean">
                 <img src='assets/images/ship.png' style='width: 100%;'>
                 <div style='margin-top:20px' data-bind="foreach: GameHelper.enumStrings(GameConstants.Region)">
+                    <!-- ko if: $data !== 'none' -->
                     <button class='btn btn-block btn-success'
                         data-dismiss='modal'
                         data-bind='visible: player.region != GameConstants.Region[$data] && GameConstants.Region[$data] <= player.highestRegion() && GameConstants.Region[$data] <= GameConstants.MAX_AVAILABLE_REGION,
@@ -17,6 +18,7 @@
                         text: GameConstants.camelCaseToString($data)'>
                         Region
                     </button>
+                    <!-- /ko -->
                 </div>
             </div>
         </div>

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -303,6 +303,7 @@ namespace GameConstants {
     }
 
     export enum Region {
+        none = -1,
         kanto = 0,
         johto = 1,
         hoenn = 2,

--- a/src/scripts/party/Party.ts
+++ b/src/scripts/party/Party.ts
@@ -99,7 +99,7 @@ class Party implements Feature {
         for (const pokemon of this.caughtPokemon) {
             let multiplier = 1;
             const nativeRegion = PokemonHelper.calcNativeRegion(pokemon.name);
-            if (nativeRegion != player.region && nativeRegion != Infinity) {
+            if (nativeRegion != player.region && nativeRegion != GameConstants.Region.none) {
                 // Pokemon only retain 20% of their total damage in other regions.
                 multiplier = 0.2;
             }

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -98,7 +98,7 @@ class PokemonHelper {
         }
         const id = pokemon.id;
         const region = GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= id);
-        return region >= 0 ? region : Infinity;
+        return region >= 0 ? region : GameConstants.Region.none;
     }
 
     public static getPokemonRegionRoutes(pokemonName: string) {

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -93,7 +93,7 @@ class PokemonHelper {
 
     public static calcNativeRegion(pokemonName: string) {
         const pokemon = pokemonMap[pokemonName];
-        if (pokemon.nativeRegion) {
+        if (pokemon.nativeRegion != undefined) {
             return pokemon.nativeRegion;
         }
         const id = pokemon.id;

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -92,7 +92,7 @@ class PokemonHelper {
 
 
     public static calcNativeRegion(pokemonName: string) {
-        const pokemon = PokemonHelper.getPokemonByName(pokemonName);
+        const pokemon = pokemonMap[pokemonName];
         if (pokemon.nativeRegion) {
             return pokemon.nativeRegion;
         }

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -93,10 +93,10 @@ class PokemonHelper {
 
     public static calcNativeRegion(pokemonName: string) {
         const pokemon = PokemonHelper.getPokemonByName(pokemonName);
-        const id = pokemon.id;
-        if (id <= 0) {
-            return Infinity;
+        if (pokemon.nativeRegion) {
+            return pokemon.nativeRegion;
         }
+        const id = pokemon.id;
         const region = GameConstants.TotalPokemonsPerRegion.findIndex(maxRegionID => maxRegionID >= id);
         return region >= 0 ? region : Infinity;
     }

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -10,6 +10,7 @@ const pokemonDevolutionMap: { [name: string]: string } = {};
 type PokemonListData = {
   id: number;
   name: string;
+  nativeRegion?: GameConstants.Region;
   catchRate: number;
   evolutions?: Evolution[];
   type: PokemonType[];
@@ -14181,6 +14182,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': 0,
             'name': 'MissingNo.',
+            'nativeRegion': GameConstants.Region.none,
             'catchRate': 45,
             'type': [PokemonType.Flying, PokemonType.Normal],
             'levelType': LevelType.mediumslow,
@@ -14199,6 +14201,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -1,
             'name': 'Flying Pikachu',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 50,
             'type': [PokemonType.Electric, PokemonType.Flying],
             'levelType': LevelType.mediumfast,
@@ -14216,6 +14219,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -2,
             'name': 'Surfing Pikachu',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 50,
             'type': [PokemonType.Electric, PokemonType.Water],
             'levelType': LevelType.mediumfast,
@@ -14233,6 +14237,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -3,
             'name': 'Armored Mewtwo',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 2,
             'type': [PokemonType.Psychic],
             'levelType': LevelType.slow,
@@ -14250,6 +14255,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -4,
             'name': 'Santa Dragonite',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 20,
             'type': [PokemonType.Dragon, PokemonType.Flying],
             'levelType': LevelType.slow,
@@ -14267,6 +14273,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -5,
             'name': 'Spooky Togepi',
+            'nativeRegion': GameConstants.Region.johto,
             'catchRate': 30,
             'type': [PokemonType.Fairy],
             'levelType': LevelType.fast,
@@ -14284,6 +14291,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -6,
             'name': 'Spooky Bulbasaur',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 25,
             'type': [PokemonType.Grass, PokemonType.Poison],
             'levelType': LevelType.mediumslow,
@@ -14301,6 +14309,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -7,
             'name': 'Pikachu (Gengar)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 50,
             'type': [PokemonType.Electric],
             'levelType': LevelType.mediumfast,
@@ -14318,6 +14327,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -8,
             'name': 'Lets go Pikachu',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 50,
             'type': [PokemonType.Electric],
             'levelType': LevelType.mediumfast,
@@ -14335,6 +14345,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -9,
             'name': 'Lets go Eevee',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 255,
             'type': [PokemonType.Normal],
             'levelType': LevelType.mediumfast,
@@ -14352,6 +14363,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -10,
             'name': 'Bulbasaur (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Grass, PokemonType.Poison],
             'levelType': LevelType.mediumslow,
@@ -14370,6 +14382,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -11,
             'name': 'Ivysaur (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Grass, PokemonType.Poison],
             'levelType': LevelType.mediumslow,
@@ -14388,6 +14401,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -12,
             'name': 'Venusaur (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Grass, PokemonType.Poison],
             'levelType': LevelType.mediumslow,
@@ -14405,6 +14419,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -13,
             'name': 'Charmander (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Fire],
             'levelType': LevelType.mediumslow,
@@ -14423,6 +14438,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -14,
             'name': 'Charmeleon (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Fire],
             'levelType': LevelType.mediumslow,
@@ -14441,6 +14457,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -15,
             'name': 'Charizard (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Fire, PokemonType.Flying],
             'levelType': LevelType.mediumslow,
@@ -14458,6 +14475,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -16,
             'name': 'Squirtle (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Water],
             'levelType': LevelType.mediumslow,
@@ -14476,6 +14494,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -17,
             'name': 'Wartortle (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Water],
             'levelType': LevelType.mediumslow,
@@ -14494,6 +14513,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -18,
             'name': 'Blastoise (clone)',
+            'nativeRegion': GameConstants.Region.kanto,
             'catchRate': 45,
             'type': [PokemonType.Water],
             'levelType': LevelType.mediumslow,
@@ -14512,6 +14532,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -100,
             'name': 'Mega Venusaur',
+            'nativeRegion': GameConstants.Region.kanto,
             'type': [PokemonType.Grass, PokemonType.Poison],
             'eggCycles': 120,
             'levelType': LevelType.mediumslow,
@@ -14529,6 +14550,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -101,
             'name': 'Mega Charizard X',
+            'nativeRegion': GameConstants.Region.kanto,
             'type': [PokemonType.Fire, PokemonType.Dragon],
             'eggCycles': 120,
             'levelType': LevelType.mediumslow,
@@ -14699,6 +14721,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -111,
             'name': 'Mega Gyarados',
+            'nativeRegion': GameConstants.Region.kanto,
             'type': [PokemonType.Water, PokemonType.Dark],
             'eggCycles': 120,
             'levelType': LevelType.slow,
@@ -14767,6 +14790,7 @@ const pokemonList: PokemonListData[] =
         {
             'id': -115,
             'name': 'Mega Rayquaza',
+            'nativeRegion': GameConstants.Region.hoenn,
             'type': [PokemonType.Dragon, PokemonType.Flying],
             'eggCycles': 120,
             'levelType': LevelType.slow,


### PR DESCRIPTION
Added region `none` to `GameConstants.Region`
Added `nativeRegion` to `PokemonList`
Updated `calcNativeRegion` to use the `nativeRegion` from `PokemonList` where applicable, otherwise just uses the Pokemons ID.