### PR TITLE
Add item drops to wild pokemon

### DIFF
--- a/src/components/pokedex.html
+++ b/src/components/pokedex.html
@@ -73,6 +73,13 @@ aria-labelledby="pokedexModalLabel">
                                       value="false" onclick="PokedexHelper.updateList()"> Not Shiny
                            </label>
                        </div>
+                       <!--Rare Hold Item-->
+                       <div class="col-sm-2">
+                           <label class="form-check-label">
+                               <input class="form-check-input" type="checkbox" id="pokedex-filter-held-item"
+                                      value="false" onclick="PokedexHelper.updateList()"> Rare Hold Item
+                           </label>
+                       </div>
 
                    </div>
 

--- a/src/components/pokemonStatisticsModal.html
+++ b/src/components/pokemonStatisticsModal.html
@@ -34,6 +34,10 @@
                       <td class="text-left">Hatch Steps</td>
                       <td class="text-left tight"><code data-bind="text: App.game.breeding.getSteps(pokemonMap[$data].eggCycles).toLocaleString('en-US')">-</code></td>
                     </tr>
+                    <tr data-bind="if: ItemList[pokemonMap[$data].heldItem]">
+                      <td class="text-left">Rare Hold Item</td>
+                      <td class="text-left tight"><code data-bind="text: GameConstants.humanifyString(ItemList[pokemonMap[$data].heldItem].name())"></code></td>
+                    </tr>
                   </tbody>
                   <thead>
                     <tr class="text-light">

--- a/src/scripts/Battle.ts
+++ b/src/scripts/Battle.ts
@@ -68,20 +68,12 @@ class Battle {
      */
     public static defeatPokemon() {
         const enemyPokemon = this.enemyPokemon();
-        GameHelper.incrementObservable(App.game.statistics.pokemonDefeated[enemyPokemon.id]);
-        GameHelper.incrementObservable(App.game.statistics.totalPokemonDefeated);
-        App.game.wallet.gainMoney(enemyPokemon.money);
-        App.game.party.gainExp(enemyPokemon.exp, enemyPokemon.level, false);
-        this.gainShardsAfterBattle();
+        enemyPokemon.defeat();
 
         GameHelper.incrementObservable(App.game.statistics.routeKills[player.route()]);
 
         App.game.breeding.progressEggsBattle(player.route(), player.region);
         const isShiny: boolean = enemyPokemon.shiny;
-        if (isShiny) {
-            GameHelper.incrementObservable(App.game.statistics.shinyPokemonDefeated[enemyPokemon.id]);
-            GameHelper.incrementObservable(App.game.statistics.totalShinyPokemonDefeated);
-        }
         const pokeBall: GameConstants.Pokeball = App.game.pokeballs.calculatePokeballToUse(enemyPokemon.id, isShiny);
 
         if (pokeBall !== GameConstants.Pokeball.None) {
@@ -100,12 +92,6 @@ class Battle {
         }
         this.gainItem();
         player.lowerItemMultipliers();
-    }
-
-    protected static gainShardsAfterBattle() {
-        const pokemon: BattlePokemon = this.enemyPokemon();
-        App.game.shards.gainShards(pokemon.shardReward, pokemon.type1);
-        App.game.shards.gainShards(pokemon.shardReward, pokemon.type2);
     }
 
     /**

--- a/src/scripts/GameConstants.ts
+++ b/src/scripts/GameConstants.ts
@@ -112,6 +112,7 @@ namespace GameConstants {
         quest_ready_to_complete: new BooleanSetting('notification.quest_ready_to_complete', 'Quest is ready to be completed', true),
         underground_energy_full: new BooleanSetting('notification.underground_energy_full', 'Mining energy reached maximum capacity', true),
         event_start_end: new BooleanSetting('notification.event_start_end', 'Event start/end information', true),
+        dropped_item: new BooleanSetting('notification.dropped_item', 'Enemy pokemon dropped an item', true),
     };
 
     export enum DungeonTile {
@@ -120,6 +121,10 @@ namespace GameConstants {
         chest,
         boss,
     }
+
+    // Held item chance
+    export const ROUTE_HELD_ITEM_CHANCE = 512;
+    export const DUNGEON_HELD_ITEM_CHANCE = 128;
 
     //Shards from battle
     export const DUNGEON_SHARDS = 3;

--- a/src/scripts/dungeons/DungeonBattle.ts
+++ b/src/scripts/dungeons/DungeonBattle.ts
@@ -9,19 +9,12 @@ class DungeonBattle extends Battle {
             DungeonRunner.fightingBoss(false);
             DungeonRunner.defeatedBoss(true);
         }
-        App.game.party.gainExp(this.enemyPokemon().exp, this.enemyPokemon().level, false);
-        this.gainShardsAfterBattle();
-        GameHelper.incrementObservable(App.game.statistics.pokemonDefeated[this.enemyPokemon().id]);
-        GameHelper.incrementObservable(App.game.statistics.totalPokemonDefeated);
+        this.enemyPokemon().defeat();
         App.game.breeding.progressEggsBattle(DungeonRunner.dungeon.itemRoute, player.region);
         DungeonRunner.map.currentTile().type(GameConstants.DungeonTile.empty);
         DungeonRunner.map.currentTile().calculateCssClass();
 
         const isShiny: boolean = this.enemyPokemon().shiny;
-        if (isShiny) {
-            GameHelper.incrementObservable(App.game.statistics.shinyPokemonDefeated[this.enemyPokemon().id]);
-            GameHelper.incrementObservable(App.game.statistics.totalShinyPokemonDefeated);
-        }
         const pokeBall: GameConstants.Pokeball = App.game.pokeballs.calculatePokeballToUse(this.enemyPokemon().id, isShiny);
 
         if (pokeBall !== GameConstants.Pokeball.None) {

--- a/src/scripts/gym/GymBattle.ts
+++ b/src/scripts/gym/GymBattle.ts
@@ -9,9 +9,8 @@ class GymBattle extends Battle {
      * Award the player with exp, and go to the next pokemon
      */
     public static defeatPokemon() {
-        App.game.party.gainExp(this.enemyPokemon().exp, this.enemyPokemon().level, false);
+        this.enemyPokemon().defeat(true);
         App.game.breeding.progressEggsBattle(this.gym.badgeReq * 3 + 1, player.region);
-        this.gainShardsAfterBattle();
         this.index(this.index() + 1);
 
         if (this.index() >= this.gym.pokemons.length) {

--- a/src/scripts/logBook/LogBookTypes.ts
+++ b/src/scripts/logBook/LogBookTypes.ts
@@ -3,7 +3,7 @@ interface LogBookType {
     label: string;
 }
 
-const LogBookTypes = {
+const LogBookTypes: Record<string, LogBookType> = {
     NEW: {
         display: 'primary',
         label: 'NEW',
@@ -19,5 +19,9 @@ const LogBookTypes = {
     ESCAPED: {
         display: 'danger',
         label: 'ESCAPED',
+    },
+    FOUND: {
+        display: 'primary',
+        label: 'FOUND',
     },
 };

--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -116,6 +116,11 @@ class PokedexHelper {
                 return false;
             }
 
+            // Only pokemon with a hold item
+            if (filter['held-item'] && !ItemList[pokemon.heldItem]) {
+                return false;
+            }
+
             return true;
         });
     }
@@ -131,6 +136,7 @@ class PokedexHelper {
         res['uncaught'] = (<HTMLInputElement> document.getElementById('pokedex-filter-uncaught')).checked;
         res['shiny'] = (<HTMLInputElement> document.getElementById('pokedex-filter-shiny')).checked;
         res['not-shiny'] = (<HTMLInputElement> document.getElementById('pokedex-filter-not-shiny')).checked;
+        res['held-item'] = (<HTMLInputElement> document.getElementById('pokedex-filter-held-item')).checked;
         return res;
     }
 

--- a/src/scripts/pokemons/BattlePokemon.ts
+++ b/src/scripts/pokemons/BattlePokemon.ts
@@ -66,7 +66,9 @@ class BattlePokemon implements EnemyPokemonInterface {
             const item = ItemList[this.heldItem];
             const name = GameConstants.humanifyString(item.name());
             item.gain(1);
-            Notifier.notify({ message: `The enemy ${this.name} dropped ${GameHelper.anOrA(name)} ${name}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.dropped_item });
+            const msg = `${this.name} dropped ${GameHelper.anOrA(name)} ${name}!`;
+            Notifier.notify({ message: `The enemy ${msg}`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.dropped_item });
+            App.game.logbook.newLog(LogBookTypes.FOUND, `An enemy ${msg}`);
         }
         App.game.party.gainExp(this.exp, this.level, trainer);
         App.game.shards.gainShards(this.shardReward, this.type1);

--- a/src/scripts/pokemons/BattlePokemon.ts
+++ b/src/scripts/pokemons/BattlePokemon.ts
@@ -55,6 +55,21 @@ class BattlePokemon implements EnemyPokemonInterface {
         this.healthPercentage(Math.floor(this.health() / this.maxHealth() * 100));
     }
 
+    public defeat(trainer = false): void {
+        GameHelper.incrementObservable(App.game.statistics.pokemonDefeated[this.id]);
+        GameHelper.incrementObservable(App.game.statistics.totalPokemonDefeated);
+        if (this.shiny) {
+            GameHelper.incrementObservable(App.game.statistics.shinyPokemonDefeated[this.id]);
+            GameHelper.incrementObservable(App.game.statistics.totalShinyPokemonDefeated);
+        }
+
+        if (this.money) {
+            App.game.wallet.gainMoney(this.money);
+        }
+        App.game.party.gainExp(this.exp, this.level, trainer);
+        App.game.shards.gainShards(this.shardReward, this.type1);
+        App.game.shards.gainShards(this.shardReward, this.type2);
+    }
 }
 
 

--- a/src/scripts/pokemons/BattlePokemon.ts
+++ b/src/scripts/pokemons/BattlePokemon.ts
@@ -1,17 +1,8 @@
 class BattlePokemon implements EnemyPokemonInterface {
-    name: string;
-    id: number;
-    type1: PokemonType;
-    type2: PokemonType;
+
     health: KnockoutObservable<number>;
     maxHealth: KnockoutObservable<number>;
     healthPercentage: KnockoutObservable<number>;
-    level: number;
-    catchRate: number;
-    exp: number;
-    money: number;
-    shiny: boolean;
-    shardReward: number;
 
     /**
      * In case you want to manually create a Pokémon instead of generating it from the route number
@@ -25,21 +16,25 @@ class BattlePokemon implements EnemyPokemonInterface {
      * @param exp base exp reward for defeating this Pokémon
      * @param money exp base exp reward for defeating this Pokémon
      * @param shiny
+     * @param [heldItem] item to gain on defeat of this pokemon
      */
-    constructor(name: string, id: number, type1: PokemonType, type2: PokemonType, maxHealth: number, level: number, catchRate: number, exp: number, money: number, shiny: boolean, shardReward = 1) {
-        this.name = name;
-        this.id = id;
-        this.type1 = type1;
-        this.type2 = type2;
+    constructor(
+        public name: string,
+        public id: number,
+        public type1: PokemonType,
+        public type2: PokemonType,
+        maxHealth: number,
+        public level: number,
+        public catchRate: number,
+        public exp: number,
+        public money: number,
+        public shiny: boolean,
+        public shardReward = 1,
+        public heldItem?: string
+    ) {
         this.health = ko.observable(maxHealth);
         this.maxHealth = ko.observable(maxHealth);
         this.healthPercentage = ko.observable(100);
-        this.level = level;
-        this.catchRate = catchRate;
-        this.exp = exp;
-        this.money = money;
-        this.shiny = shiny;
-        this.shardReward = shardReward;
     }
 
     public isAlive(): boolean {
@@ -65,6 +60,13 @@ class BattlePokemon implements EnemyPokemonInterface {
 
         if (this.money) {
             App.game.wallet.gainMoney(this.money);
+        }
+
+        if (this.heldItem && ItemList[this.heldItem]) {
+            const item = ItemList[this.heldItem];
+            const name = GameConstants.humanifyString(item.name());
+            item.gain(1);
+            Notifier.notify({ message: `The enemy ${this.name} dropped ${GameHelper.anOrA(name)} ${name}!`, type: GameConstants.NotificationOption.success, setting: GameConstants.NotificationSetting.dropped_item });
         }
         App.game.party.gainExp(this.exp, this.level, trainer);
         App.game.shards.gainShards(this.shardReward, this.type1);

--- a/src/scripts/pokemons/DataPokemon.ts
+++ b/src/scripts/pokemons/DataPokemon.ts
@@ -1,27 +1,19 @@
 class DataPokemon implements PokemonInterface {
-    id: number;
-    name: string;
-    catchRate: number;
-    evolutions: Evolution[];
-    type1: PokemonType;
-    type2: PokemonType;
-    attack: number;
-    levelType: LevelType;
-    exp: number;
-    eggCycles: number;
     shiny: boolean;
 
-    constructor(id: number, name: string, catchRate: number, evolutions: Evolution[], type1: PokemonType, type2: PokemonType, attack: number, levelType: LevelType, exp: number, eggCycles: number) {
-        this.id = id;
-        this.name = name;
-        this.catchRate = catchRate;
-        this.evolutions = evolutions;
-        this.type1 = type1;
-        this.type2 = type2;
-        this.attack = attack;
-        this.levelType = levelType;
-        this.exp = exp;
-        this.eggCycles = eggCycles;
+    constructor(
+        public id: number,
+        public name: string,
+        public catchRate: number,
+        public evolutions: Evolution[],
+        public type1: PokemonType,
+        public type2: PokemonType,
+        public attack: number,
+        public levelType: LevelType,
+        public exp: number,
+        public eggCycles: number,
+        public heldItem: string | null
+    ) {
         this.shiny = false;
     }
 

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -163,8 +163,9 @@ class PokemonFactory {
             return null;
         }
 
-        const itemBonus = 1;
-        chance /= itemBonus;
+        if (EffectEngineRunner.isActive(GameConstants.BattleItemType.Item_magnet)()) {
+            chance /= 1.5;
+        }
         const rand: number = Math.floor(Math.random() * chance) + 1;
         if (rand <= 1) {
             return item;

--- a/src/scripts/pokemons/PokemonFactory.ts
+++ b/src/scripts/pokemons/PokemonFactory.ts
@@ -31,13 +31,14 @@ class PokemonFactory {
         const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         const exp: number = basePokemon.exp;
         const level: number = this.routeLevel(route, region);
+        const heldItem: string = this.generateHeldItem(basePokemon.heldItem, GameConstants.ROUTE_HELD_ITEM_CHANCE);
 
         const money: number = this.routeMoney(route,region);
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         if (shiny) {
             Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
         }
-        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny);
+        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, 1, heldItem);
     }
 
     public static routeLevel(route: number, region: GameConstants.Region): number {
@@ -113,11 +114,12 @@ class PokemonFactory {
         const catchRate: number = this.catchRateHelper(basePokemon.catchRate);
         const exp: number = basePokemon.exp;
         const money = 0;
+        const heldItem = this.generateHeldItem(basePokemon.heldItem, GameConstants.DUNGEON_HELD_ITEM_CHANCE);
         const shiny: boolean = this.generateShiny(GameConstants.SHINY_CHANCE_BATTLE);
         if (shiny) {
             Notifier.notify({ message: `✨ You encountered a shiny ${name}! ✨`, type: GameConstants.NotificationOption.warning, sound: GameConstants.NotificationSound.shiny_long, setting: GameConstants.NotificationSetting.encountered_shiny });
         }
-        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, GameConstants.DUNGEON_SHARDS);
+        return new BattlePokemon(name, id, basePokemon.type1, basePokemon.type2, maxHealth, level, catchRate, exp, money, shiny, GameConstants.DUNGEON_SHARDS, heldItem);
     }
 
     public static generateDungeonBoss(bossPokemonList: DungeonBossPokemon[], chestsOpened: number): BattlePokemon {
@@ -154,5 +156,20 @@ class PokemonFactory {
         const catchVariation = noVariation ? 0 : GameConstants.randomIntBetween(-3, 3);
         const catchRateRaw = Math.floor(Math.pow(baseCatchRate, 0.75)) + catchVariation;
         return GameConstants.clipNumber(catchRateRaw, 0, 100);
+    }
+
+    private static generateHeldItem(item: string, chance: number): string | null {
+        if (!item || !ItemList[item]) {
+            return null;
+        }
+
+        const itemBonus = 1;
+        chance /= itemBonus;
+        const rand: number = Math.floor(Math.random() * chance) + 1;
+        if (rand <= 1) {
+            return item;
+        }
+
+        return null;
     }
 }

--- a/src/scripts/pokemons/PokemonHelper.ts
+++ b/src/scripts/pokemons/PokemonHelper.ts
@@ -57,7 +57,7 @@ class PokemonHelper {
         const type2: PokemonType = basePokemon['type'][1] ?? PokemonType.None;
 
         const eggCycles: number = basePokemon['eggCycles'] || 20;
-        return new DataPokemon(basePokemon['id'], basePokemon['name'], basePokemon['catchRate'], basePokemon['evolutions'], type1, type2, basePokemon['attack'], basePokemon['levelType'], basePokemon['exp'], eggCycles);
+        return new DataPokemon(basePokemon['id'], basePokemon['name'], basePokemon['catchRate'], basePokemon['evolutions'], type1, type2, basePokemon['attack'], basePokemon['levelType'], basePokemon['exp'], eggCycles, basePokemon['heldItem']);
     }
 
     public static typeStringToId(id: string) {

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -1445,6 +1445,7 @@ const pokemonList: PokemonListData[] =
                 'specialDefense': 80,
                 'speed': 30,
             },
+            'heldItem': 'Kings_rock',
         },
         {
             'id': 81,
@@ -2619,6 +2620,7 @@ const pokemonList: PokemonListData[] =
                 'specialDefense': 50,
                 'speed': 50,
             },
+            'heldItem': 'Dragon_scale',
         },
         {
             'id': 148,
@@ -4013,6 +4015,7 @@ const pokemonList: PokemonListData[] =
                 'specialDefense': 70,
                 'speed': 70,
             },
+            'heldItem': 'Metal_coat',
         },
         {
             'id': 228,

--- a/src/scripts/pokemons/PokemonList.ts
+++ b/src/scripts/pokemons/PokemonList.ts
@@ -27,6 +27,7 @@ type PokemonListData = {
   eggCycles: number;
   baby?: boolean;
   attack?: number;
+  heldItem?: string;
 }
 
 /**


### PR DESCRIPTION
Allows us to specify an item in pokemonList that will occasionally be dropped on defeating that pokemon in a dungeon or route.

Route chance is set so that it takes 1-2 hours for each item
Dungeon chance might need to be improved

Also adds these items to the pokemon information in the pokedex, and adds a filter to only show pokemon that can drop an item, to hopefully make players aware that this is a thing that can happen.

The notification could do with a sound, but I have no idea where to get or make one

Added Kings Rock to Slowbro, Metal Coat to Skarmory, and Dragon Scale to Dratini.
These items are still available in shops and the underground - shops so that players can pay to avoid RNG, and underground because I didn't want to break any deal chains people have going. May want to revisit the underground with Sinnoh release.