### PR TITLE
Attempt to avoid underground memory leaking

### DIFF
--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -115,7 +115,7 @@ class Mine {
                     if (Mine.grid[Mine.normalizeY(x + i)][Mine.normalizeX(y + j)]() > 0) {
                         hasMined = true;
                     }
-                    Mine.grid[Mine.normalizeY(x + i)][Mine.normalizeX(y + j)](Math.max(0, Mine.grid[Mine.normalizeY(x + i)][Mine.normalizeX(y + j)]() - 1));
+                    this.breakTile(x + i, y + j, 1);
                 }
             }
             if (hasMined) {
@@ -127,9 +127,24 @@ class Mine {
     private static chisel(x: number, y: number) {
         if (Mine.grid[x][y]() > 0) {
             if (Underground.energy >= Underground.CHISEL_ENERGY) {
-                Mine.grid[Mine.normalizeY(x)][Mine.normalizeX(y)](Math.max(0, Mine.grid[Mine.normalizeY(x)][Mine.normalizeX(y)]() - 2));
+                this.breakTile(x, y, 2);
                 Underground.energy = Underground.energy - Underground.CHISEL_ENERGY;
             }
+        }
+    }
+
+    private static breakTile(_x: number, _y: number, layers = 1) {
+        const x = Mine.normalizeY(_x);
+        const y = Mine.normalizeX(_y);
+        const newlayer = Math.max(0, Mine.grid[x][y]() - layers);
+
+        Mine.grid[x][y](newlayer);
+
+        const reward = Mine.rewardGrid[x][y];
+        if (newlayer == 0 && reward != 0 && reward.revealed != 1) {
+            reward.revealed = 1;
+            $(`div[data-i=${x}][data-j=${y}]`).html(`<div class="mineReward size-${reward.sizeX}-${reward.sizeY} pos-${reward.x}-${reward.y}" style="background-image: url('assets/images/underground/${reward.value}.png');"></div>`);
+            Mine.checkItemsRevealed();
         }
     }
 

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -52,28 +52,14 @@ class Underground {
     private static mineSquare(amount: number, i: number, j: number): string {
         if (Mine.rewardGrid[i][j] != 0 && Mine.grid[i][j]() === 0) {
             Mine.rewardGrid[i][j].revealed = 1;
-            return `<div data-bind='css: Underground.calculateCssClass(${i},${j})()' data-i='${i}' data-j='${j}'><div class="mineReward size-${Mine.rewardGrid[i][j].sizeX}-${Mine.rewardGrid[i][j].sizeY} pos-${Mine.rewardGrid[i][j].x}-${Mine.rewardGrid[i][j].y}" style="background-image: url('assets/images/underground/${Mine.rewardGrid[i][j].value}.png');"></div></div>`;
+            return `<div data-bind='css: Underground.calculateCssClass(${i},${j})' data-i='${i}' data-j='${j}'><div class="mineReward size-${Mine.rewardGrid[i][j].sizeX}-${Mine.rewardGrid[i][j].sizeY} pos-${Mine.rewardGrid[i][j].x}-${Mine.rewardGrid[i][j].y}" style="background-image: url('assets/images/underground/${Mine.rewardGrid[i][j].value}.png');"></div></div>`;
         } else {
-            return `<div data-bind='css: Underground.calculateCssClass(${i},${j})()' data-i='${i}' data-j='${j}'></div>`;
+            return `<div data-bind='css: Underground.calculateCssClass(${i},${j})' data-i='${i}' data-j='${j}'></div>`;
         }
     }
 
-    public static calculateCssClass(i: number, j: number): KnockoutComputed<string> {
-        // disposed via the disposeWhen function passed as an option
-        return ko.computed(function () {
-            return `col-sm-1 rock${Math.max(Mine.grid[i][j](), 0)} mineSquare ${Mine.Tool[Mine.toolSelected()]}Selected`;
-        }, this, {
-            disposeWhen: function () {
-                if (Mine.grid[i][j]() == 0) {
-                    if (Mine.rewardGrid[i][j] != 0 && Mine.rewardGrid[i][j].revealed != 1) {
-                        Mine.rewardGrid[i][j].revealed = 1;
-                        $(`div[data-i=${i}][data-j=${j}]`).html(`<div class="mineReward size-${Mine.rewardGrid[i][j].sizeX}-${Mine.rewardGrid[i][j].sizeY} pos-${Mine.rewardGrid[i][j].x}-${Mine.rewardGrid[i][j].y}" style="background-image: url('assets/images/underground/${Mine.rewardGrid[i][j].value}.png');"></div>`);
-                        Mine.checkItemsRevealed();
-                    }
-                }
-                return false;
-            },
-        });
+    public static calculateCssClass(i: number, j: number): string {
+        return `col-sm-1 rock${Math.max(Mine.grid[i][j](), 0)} mineSquare ${Mine.Tool[Mine.toolSelected()]}Selected`;
     }
 
     private static rewardCssClass: KnockoutComputed<string> = ko.pureComputed(function () {


### PR DESCRIPTION
Firefox is telling me that we gain around 15MB of memory usage every mine layer we complete - not ideal.
Investigation points at calculateCssClass. I can't see exactly why the disposeWhen isn't working as it should, maybe all of the tiles we don't mine are allowed to linger? In any case, it seems weird to be doing some of those things in a css calculator, so I have moved the side-effecty things into Mine.ts, and allowed the calculateCssClass to return a string, letting knockout do any computed construction and disposal for us.

I am no longer getting the memory leakage from the underground with this change.