### PR TITLE
Add Prospect, Bomb, and Skip actions to the underground

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -54,6 +54,7 @@ style="cursor:default" tabindex="-1">
                             </button>
                         </div>
                         <button class='col-12 col-md-4 btn btn-success' onClick='Mine.prospect()'>Prospect (<knockout data-bind="text: Underground.PROSPECT_ENERGY"></knockout> energy)</button>
+                        <button class='col-12 col-md-4 btn btn-warning' onClick='Mine.bomb(10)'>Bomb (<knockout data-bind="text: Underground.CHISEL_ENERGY * 10"></knockout> energy)</button>
                       </div>
                 </div>
                 <div id="treasures" class="tab-pane fade">

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -45,7 +45,15 @@ style="cursor:default" tabindex="-1">
                     <div class='row'>
                         <button class='col-12 col-md-4 btn btn-primary' onClick='Mine.toolSelected(Mine.Tool.Hammer)'>Hammer (<knockout data-bind="text: Underground.HAMMER_ENERGY"></knockout> energy)</button>
                         <button class='col-12 col-md-4 btn btn-info' onClick='Mine.toolSelected(Mine.Tool.Chisel)'>Chisel (<knockout data-bind="text: Underground.CHISEL_ENERGY"></knockout> energy)</button>
-                        <button class='col-12 col-md-4 btn' data-bind="text: Mine.itemsFound() + ' / ' + Mine.itemsBuried + ' items found'"></button>
+                        <div class='col-12 col-md-4'>
+                            <button class='btn' data-bind="text: Mine.itemsFound() + ' / ' + Mine.itemsBuried + ' items found'"></button>
+                            <button id="mine-prospect-result" type="button" class="btn btn-info" data-html="true"
+                                    style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px; padding: 4px;"
+                                    data-bind="tooltip: { title: () => Mine.prospectResult() ?? 'Prospect to get more details', trigger: 'hover', placement:'left' }">
+                                ?
+                            </button>
+                        </div>
+                        <button class='col-12 col-md-4 btn btn-success' onClick='Mine.prospect()'>Prospect (<knockout data-bind="text: Underground.PROSPECT_ENERGY"></knockout> energy)</button>
                       </div>
                 </div>
                 <div id="treasures" class="tab-pane fade">

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -46,7 +46,7 @@ style="cursor:default" tabindex="-1">
                         <button class='col-12 col-md-4 btn btn-primary' onClick='Mine.toolSelected(Mine.Tool.Hammer)'>Hammer (<knockout data-bind="text: Underground.HAMMER_ENERGY"></knockout> energy)</button>
                         <button class='col-12 col-md-4 btn btn-info' onClick='Mine.toolSelected(Mine.Tool.Chisel)'>Chisel (<knockout data-bind="text: Underground.CHISEL_ENERGY"></knockout> energy)</button>
                         <div class='col-12 col-md-4'>
-                            <button class='btn' data-bind="text: Mine.itemsFound() + ' / ' + Mine.itemsBuried + ' items found'"></button>
+                            <button class='btn' data-bind="text: Mine.itemsFound() + ' / ' + Mine.itemsBuried() + ' items found'"></button>
                             <button id="mine-prospect-result" type="button" class="btn btn-info" data-html="true"
                                     style="position: absolute; right: 0px; top: 0px; width: auto; height: 41px; padding: 4px;"
                                     data-bind="tooltip: { title: () => Mine.prospectResult() ?? 'Prospect to get more details', trigger: 'hover', placement:'left' }">

--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -55,6 +55,7 @@ style="cursor:default" tabindex="-1">
                         </div>
                         <button class='col-12 col-md-4 btn btn-success' onClick='Mine.prospect()'>Prospect (<knockout data-bind="text: Underground.PROSPECT_ENERGY"></knockout> energy)</button>
                         <button class='col-12 col-md-4 btn btn-warning' onClick='Mine.bomb(10)'>Bomb (<knockout data-bind="text: Underground.CHISEL_ENERGY * 10"></knockout> energy)</button>
+                        <button class='col-12 col-md-4 btn btn-danger' onClick='Mine.skipLayer(true)'>Skip (<knockout data-bind="text: `${Mine.skipsRemaining()} / ${Mine.maxSkips}`"></knockout>)</button>
                       </div>
                 </div>
                 <div id="treasures" class="tab-pane fade">

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -196,6 +196,18 @@ class Mine {
         }
     }
 
+    private static bomb(tiles = 10) {
+        if (Underground.energy >= Underground.CHISEL_ENERGY * tiles) {
+            for (let i = 1; i < tiles; i++) {
+                const x = GameConstants.randomIntBetween(1, this.sizeY - 2);
+                const y = GameConstants.randomIntBetween(1, this.sizeX - 2);
+                this.breakTile(x, y, 2);
+            }
+
+            Underground.energy -= Underground.CHISEL_ENERGY * tiles;
+        }
+    }
+
     private static breakTile(_x: number, _y: number, layers = 1) {
         const x = Mine.normalizeY(_x);
         const y = Mine.normalizeX(_y);

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -5,7 +5,7 @@ class Mine {
     public static grid: Array<Array<KnockoutObservable<number>>>;
     public static rewardGrid: Array<Array<any>>;
     public static itemsFound: KnockoutObservable<number> = ko.observable(0);
-    public static itemsBuried: number;
+    public static itemsBuried: KnockoutObservable<number> = ko.observable(0);
     public static rewardNumbers: Array<number>;
     public static prospectResult = ko.observable(null);
     public static skipsRemaining = ko.observable(Mine.maxSkips)
@@ -18,7 +18,7 @@ class Mine {
         const tmpGrid = [];
         const tmpRewardGrid = [];
         Mine.rewardNumbers = [];
-        Mine.itemsBuried = 0;
+        Mine.itemsBuried(0);
         Mine.prospectResult(null);
         for (let i = 0; i < this.sizeY; i++) {
             const row = [];
@@ -96,7 +96,7 @@ class Mine {
                 }
             }
         }
-        Mine.itemsBuried++;
+        GameHelper.incrementObservable(Mine.itemsBuried);
         Mine.rewardNumbers.push(reward.id);
     }
 
@@ -278,7 +278,7 @@ class Mine {
     }
 
     private static checkCompleted() {
-        if (Mine.itemsFound() >= Mine.itemsBuried) {
+        if (Mine.itemsFound() >= Mine.itemsBuried()) {
             setTimeout(Mine.completed, 1500);
             Mine.loadingNewLayer = true;
             GameHelper.incrementObservable(App.game.statistics.undergroundLayersMined);
@@ -304,10 +304,10 @@ class Mine {
         });
         this.rewardGrid = mine.rewardGrid;
         this.itemsFound(mine.itemsFound);
-        this.itemsBuried = mine.itemsBuried;
+        this.itemsBuried(mine.itemsBuried);
         this.rewardNumbers = mine.rewardNumbers;
         this.loadingNewLayer = false;
-        this.prospectResult(mine.prospectResult ?? this.prospectResult);
+        this.prospectResult(mine.prospectResult ?? this.prospectResult());
         this.skipsRemaining(mine.skipsRemaining ?? this.maxSkips);
 
         Underground.showMine();
@@ -317,8 +317,8 @@ class Mine {
         const mine = {
             grid: this.grid,
             rewardGrid: this.rewardGrid,
-            itemsFound: this.itemsFound,
-            itemsBuried: this.itemsBuried,
+            itemsFound: this.itemsFound(),
+            itemsBuried: this.itemsBuried(),
             rewardNumbers: this.rewardNumbers,
             prospectResult: this.prospectResult(),
             skipsRemaining: this.skipsRemaining(),

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -154,7 +154,7 @@ class Mine {
         if (summary.plates) {
             text.push(`Shard Plates: ${summary.plates}`);
         }
-        text.push(`Total Value: ${summary.totalValue}`);
+        text.push(`💎 Value: ${summary.totalValue}`);
 
         Mine.prospectResult(text.join('<br>'));
         $('#mine-prospect-result').tooltip('show');

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -154,7 +154,7 @@ class Mine {
         if (summary.plates) {
             text.push(`Shard Plates: ${summary.plates}`);
         }
-        text.push(`💎 Value: ${summary.totalValue}`);
+        text.push(`Diamond Value: ${summary.totalValue}`);
 
         Mine.prospectResult(text.join('<br>'));
         $('#mine-prospect-result').tooltip('show');

--- a/src/scripts/underground/Mine.ts
+++ b/src/scripts/underground/Mine.ts
@@ -307,6 +307,7 @@ class Mine {
         this.itemsBuried = mine.itemsBuried;
         this.rewardNumbers = mine.rewardNumbers;
         this.loadingNewLayer = false;
+        this.prospectResult(mine.prospectResult ?? this.prospectResult);
         this.skipsRemaining(mine.skipsRemaining ?? this.maxSkips);
 
         Underground.showMine();
@@ -319,6 +320,7 @@ class Mine {
             itemsFound: this.itemsFound,
             itemsBuried: this.itemsBuried,
             rewardNumbers: this.rewardNumbers,
+            prospectResult: this.prospectResult(),
             skipsRemaining: this.skipsRemaining(),
         };
 

--- a/src/scripts/underground/Underground.ts
+++ b/src/scripts/underground/Underground.ts
@@ -237,4 +237,5 @@ namespace Underground {
 
     export const HAMMER_ENERGY = 3;
     export const CHISEL_ENERGY = 1;
+    export const PROSPECT_ENERGY = 15;
 }


### PR DESCRIPTION
Prospect provides a summary of what can be found in this layer, without saying the exact items.

Bomb will chisel 10 random mine tiles, no guarantee it will only hit tiles that can still be mined.

Skip will use up a skip charge to move onto the next mine layer before completing it. Skip charges are gained by completing a mine layer normally, up to a maximum of 5.