### PR TITLE
Add more information to Underground help text

### DIFF
--- a/src/components/underground.html
+++ b/src/components/underground.html
@@ -100,12 +100,23 @@ style="cursor:default" tabindex="-1">
                         </tbody>
                     </table>
                 </div>
-                <div id="help" class="tab-pane fade">
-                    <h4>In the underground you can mine for hidden treasures.</h4>
-                    <h4>Select the Hammer or the Chisel and click on the wall.</h4>
-                    <h4>Sell your treasures for shards or diamonds!</h4>
-                    <h4>You can use your diamonds to buy all kinds of upgrades that will help you explore the underground even further!</h4>
-                    <h4>In the Daily deals tab you can trade your items.</h4>
+                <div id="help" class="tab-pane fade pl-5 pr-5">
+                    <h4><u>Dig</u></h4>
+                    <p>In the underground you can mine for hidden treasures.</p>
+                    <p>There are 3 ways of breaking tiles: Chisel will mine two layers on a single tile; Hammer will mine 1 layer on all nine tiles of a 3x3 square; and Bomb will mine 2 layers of 10 random tiles.</p>
+                    <p>You can spend some mining energy to Prospect. This will give you some rough information on what can be found in this mine level.</p>
+                    <p>If you don't think this level is worth mining, you can Skip it. Skipping will use up one of your maximum of 5 charges. Every time you mine out all items in a level, you will recover one Skip charge.</p>
+
+                    <h4><u>Treasures</u></h4>
+                    <p>Sell your treasures for shards or diamonds!</p>
+                    <p>If you have found any fossils, you can hatch the pokemon they contain from the Treasures tab, or from the Day Care.</p>
+
+                    <h4><u>Upgrades</u></h4>
+                    <p>You can use your diamonds to buy all kinds of upgrades that will help you explore the underground even further!</p>
+
+                    <h4><u>Daily deals</u></h4>
+                    <p>In the Daily deals tab you can trade your items.</p>
+                    <p>These trades will change at midnight (your local time).</p>
                 </div>
                 <div id="dailyDeals" class="tab-pane fade">
                     <div class="table-responsive" id="dailyDealsBody">


### PR DESCRIPTION
Adds information about Bomb, Prospect, and Skip to the underground help text, and also separates the help text into sections for each underground tab