### PR TITLE
Remove hardcoding of badgecase

### DIFF
--- a/src/scripts/App.ts
+++ b/src/scripts/App.ts
@@ -11,13 +11,14 @@ class App {
         Preload.load(App.debug).then(() => {
             console.log(`[${GameConstants.formatDate(new Date())}] %cLoading Game Data..`, 'color:#8e44ad;font-weight:900;');
             UndergroundItem.initialize();
+            player = Save.load();
             App.game = new Game(
                 new Update(),
                 new Breeding(),
                 new Pokeballs(),
                 new Wallet(),
                 new KeyItems(),
-                new BadgeCase(BadgeCase.Badge.Elite_HoennChampion),
+                new BadgeCase(),
                 new OakItems([20, 50, 100]),
                 new Party(),
                 new Shards(),

--- a/src/scripts/Game.ts
+++ b/src/scripts/Game.ts
@@ -62,8 +62,6 @@ class Game {
 
         this._gameState = ko.observable(GameConstants.GameState.paused);
 
-        player = Save.load();
-
         AchievementHandler.initialize();
     }
 

--- a/src/scripts/badgeCase/BadgeCase.ts
+++ b/src/scripts/badgeCase/BadgeCase.ts
@@ -2,39 +2,30 @@ class BadgeCase implements Feature {
     name = 'Badge Case';
     saveKey = 'badgeCase';
 
-    badgeList: ArrayOfObservables<boolean>;
-    badgeAmount: number;
+    badgeList: KnockoutObservableArray<boolean> = ko.observableArray([]);
+    highestAvailableBadge: KnockoutComputed<number>;
     defaults: Record<string, any> = {};
 
-    constructor(highestBadge) {
-        this.badgeAmount = highestBadge + 1;
-        this.badgeList = this.createDefaultBadgeList();
-    }
-
-    private createDefaultBadgeList(): ArrayOfObservables<boolean> {
-        const list = new Array(this.badgeAmount).fill(false);
-        return new ArrayOfObservables(list);
+    constructor() {
+        this.highestAvailableBadge = ko.pureComputed(() => {
+            const region = player.highestRegion();
+            return gymList[GameConstants.RegionGyms[region][GameConstants.RegionGyms[region].length - 1]].badgeReward;
+        });
     }
 
     badgeCount() {
-        let count = 0;
-        for (let i = 0; i < this.badgeList.length; i++) {
-            if (this.badgeList[i]) {
-                count++;
-            }
-        }
-        return count;
+        return this.badgeList().reduce((a, b) => (+a) + (+b), 0);
     }
 
     gainBadge(badge: BadgeCase.Badge) {
-        this.badgeList[badge] = true;
+        this.badgeList()[badge] = true;
     }
 
     hasBadge(badge: BadgeCase.Badge) {
         if (badge == null || badge == BadgeCase.Badge.None) {
             return true;
         }
-        return this.badgeList[badge];
+        return this.badgeList()[badge];
     }
 
     initialize(): void {
@@ -50,14 +41,14 @@ class BadgeCase implements Feature {
             return;
         }
 
-        for (let i = 0; i < this.badgeList.length; i++) {
-            this.badgeList[i] = json[i];
-        }
+        json.forEach((hasBadge, index) => {
+            this.badgeList()[index] = hasBadge;
+        });
     }
 
     toJSON(): Record<string, any> {
-        return this.badgeList.map(badge => {
-            return badge;
+        return this.badgeList().map(badge => {
+            return badge || false;
         });
     }
 

--- a/src/scripts/badgeCase/BadgeCase.ts
+++ b/src/scripts/badgeCase/BadgeCase.ts
@@ -45,9 +45,8 @@ class BadgeCase implements Feature {
     }
 
     toJSON(): Record<string, any> {
-        return this.badgeList.map(badge => {
-            return badge || false;
-        });
+        let shouldReturn = false;
+        return [...this.badgeList].reverse().filter(i => shouldReturn || i && (shouldReturn = i)).reverse();
     }
 
     update(delta: number): void {

--- a/src/scripts/badgeCase/BadgeCase.ts
+++ b/src/scripts/badgeCase/BadgeCase.ts
@@ -46,6 +46,7 @@ class BadgeCase implements Feature {
 
     toJSON(): Record<string, any> {
         let shouldReturn = false;
+        // We only want to save upto the highest badge we have obtained, everything else is assumed to be false
         return [...this.badgeList].reverse().filter(i => shouldReturn || i && (shouldReturn = i)).reverse();
     }
 

--- a/src/scripts/badgeCase/BadgeCase.ts
+++ b/src/scripts/badgeCase/BadgeCase.ts
@@ -1,31 +1,29 @@
 class BadgeCase implements Feature {
     name = 'Badge Case';
     saveKey = 'badgeCase';
-
-    badgeList: KnockoutObservableArray<boolean> = ko.observableArray([]);
-    highestAvailableBadge: KnockoutComputed<number>;
     defaults: Record<string, any> = {};
 
-    constructor() {
-        this.highestAvailableBadge = ko.pureComputed(() => {
-            const region = player.highestRegion();
-            return gymList[GameConstants.RegionGyms[region][GameConstants.RegionGyms[region].length - 1]].badgeReward;
-        });
-    }
+    badgeList: ArrayOfObservables<boolean> = new ArrayOfObservables(new Array(GameConstants.RegionGyms.flat().length).fill(false));
+    highestAvailableBadge: KnockoutComputed<number> = ko.pureComputed(() => {
+        const region = player.highestRegion();
+        return gymList[GameConstants.RegionGyms[region][GameConstants.RegionGyms[region].length - 1]].badgeReward;
+    });
+
+    constructor() {}
 
     badgeCount() {
-        return this.badgeList().reduce((a, b) => (+a) + (+b), 0);
+        return this.badgeList.reduce((a, b) => (+a) + (+b), 0);
     }
 
     gainBadge(badge: BadgeCase.Badge) {
-        this.badgeList()[badge] = true;
+        this.badgeList[badge] = true;
     }
 
     hasBadge(badge: BadgeCase.Badge) {
         if (badge == null || badge == BadgeCase.Badge.None) {
             return true;
         }
-        return this.badgeList()[badge];
+        return this.badgeList[badge];
     }
 
     initialize(): void {
@@ -42,12 +40,12 @@ class BadgeCase implements Feature {
         }
 
         json.forEach((hasBadge, index) => {
-            this.badgeList()[index] = hasBadge;
+            this.badgeList[index] = hasBadge;
         });
     }
 
     toJSON(): Record<string, any> {
-        return this.badgeList().map(badge => {
+        return this.badgeList.map(badge => {
             return badge || false;
         });
     }

--- a/src/scripts/badgeCase/BadgeCaseController.ts
+++ b/src/scripts/badgeCase/BadgeCaseController.ts
@@ -1,7 +1,7 @@
 class BadgeCaseController {
     static getDisplayableBadges() {
         return Object.keys(BadgeCase.Badge).filter(b =>
-            !b.startsWith('Elite') && b != 'None' && BadgeCase.Badge[b] < App.game.badgeCase.badgeAmount
+            !b.startsWith('Elite') && b != 'None' && BadgeCase.Badge[b] <= App.game.badgeCase.highestAvailableBadge()
         );
     }
 }


### PR DESCRIPTION
Remove the hardcoding for badgecase.
Was limiting the amount of badges that would be saved.

Have also updated the badge case to display all badges available up to the players highest region.
So it won't show Hoenn badges while you are still in Kanto.