### PR TITLE
Update Johto route gym and dungeon requirements

### DIFF
--- a/src/components/JohtoSVG.html
+++ b/src/components/JohtoSVG.html
@@ -5,17 +5,17 @@
     <!-- ROUTES -->
     <!-- ------ -->
 
-    <!--Route 26-->
+    <!--Route 27-->
     <%- include('templates/mapRoute',
-        { route: 26, region: 1
+        { route: 27, region: 1
         , width: 19, height: 3
         , x: 77, y: 42
         })
      %>
 
-    <!--Route 27-->
+    <!--Route 26-->
     <%- include('templates/mapRoute',
-        { route: 27, region: 1
+        { route: 26, region: 1
         , width: 31, height: 3
         , x: 93, y: 11
         , rotate: true

--- a/src/scripts/gym/Gym.ts
+++ b/src/scripts/gym/Gym.ts
@@ -251,7 +251,7 @@ gymList['Violet City'] = new Gym(
     BadgeCase.Badge.Zephyr,
     250,
     '...For pity\'s sake! My dad\'s cherished bird Pokémon... But a defeat is a defeat. All right. Take this official Pokémon League Badge. This one is the Zephyr Badge.',
-    [new GymBadgeRequirement(BadgeCase.Badge.Elite_Lance)]
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Sprout Tower'))]
 );
 gymList['Azalea Town'] = new Gym(
     'Bugsy',
@@ -264,7 +264,7 @@ gymList['Azalea Town'] = new Gym(
     BadgeCase.Badge.Hive,
     500,
     'Whoa, amazing! You\'re an expert on Pokémon! My research isn\'t complete yet. OK, you win. Take this Hive Badge.',
-    [new GymBadgeRequirement(BadgeCase.Badge.Zephyr)]
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Slowpoke Well'))]
 );
 gymList['Goldenrod City'] = new Gym(
     'Whitney',
@@ -276,7 +276,7 @@ gymList['Goldenrod City'] = new Gym(
     BadgeCase.Badge.Plain,
     1000,
     '...Sniff... What? What do you want? A badge? Oh, right. I forgot. Here\'s the Plain Badge.',
-    [new GymBadgeRequirement(BadgeCase.Badge.Hive)]
+    [new RouteKillRequirement(10, 34)]
 );
 gymList['Ecruteak City'] = new Gym(
     'Morty',
@@ -328,7 +328,7 @@ gymList['Mahogany Town'] = new Gym(
     BadgeCase.Badge.Glacier,
     4000,
     'I am impressed by your prowess. With your strong will, I know you will overcome all life\'s obstacles. You are worthy of this Glacier Badge!',
-    [new GymBadgeRequirement(BadgeCase.Badge.Mineral)]
+    [new RouteKillRequirement(10, 43)]
 );
 gymList['Blackthorn City'] = new Gym(
     'Clair',

--- a/src/scripts/towns/Town.ts
+++ b/src/scripts/towns/Town.ts
@@ -164,22 +164,22 @@ TownList['Goldenrod City'] = new Town('Goldenrod City', [new RouteKillRequiremen
 TownList['Ecruteak City'] = new Town('Ecruteak City', [new RouteKillRequirement(10, 37)]);
 TownList['Olivine City'] = new Town('Olivine City', [new RouteKillRequirement(10, 39)], OlivineCityShop);
 TownList['Cianwood City'] = new Town('Cianwood City', [new RouteKillRequirement(10, 41)], CianwoodCityShop);
-TownList['Mahogany Town'] = new Town('Mahogany Town', [new RouteKillRequirement(10, 42), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Mt Mortar'))]);
-TownList['Blackthorn City'] = new Town('Blackthorn City', [new RouteKillRequirement(10, 44), new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ice Path'))], BlackthornCityShop);
+TownList['Mahogany Town'] = new Town('Mahogany Town', [new RouteKillRequirement(10, 42)]);
+TownList['Blackthorn City'] = new Town('Blackthorn City', [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ice Path'))], BlackthornCityShop);
 
 //Johto Dungeons
-TownList['Sprout Tower'] = new DungeonTown('Sprout Tower', [new RouteKillRequirement(10, 31), new GymBadgeRequirement(BadgeCase.Badge.Elite_KantoChampion)]);
-TownList['Ruins of Alph'] = new DungeonTown('Ruins of Alph', [new RouteKillRequirement(10, 32), new GymBadgeRequirement(BadgeCase.Badge.Zephyr)]);
-TownList['Union Cave'] = new DungeonTown('Union Cave', [new RouteKillRequirement(10, 32), new GymBadgeRequirement(BadgeCase.Badge.Zephyr)]);
-TownList['Slowpoke Well'] = new DungeonTown('Slowpoke Well', [new RouteKillRequirement(10, 33), new GymBadgeRequirement(BadgeCase.Badge.Zephyr)]);
-TownList['Ilex Forest'] = new DungeonTown('Ilex Forest', [new RouteKillRequirement(10, 33), new GymBadgeRequirement(BadgeCase.Badge.Hive)]);
-TownList['Burned Tower'] = new DungeonTown('Burned Tower', [new RouteKillRequirement(10, 37), new GymBadgeRequirement(BadgeCase.Badge.Fog)]);
-TownList['Tin Tower'] = new DungeonTown('Tin Tower', [new RouteKillRequirement(10, 37), new GymBadgeRequirement(BadgeCase.Badge.Fog)]);
-TownList['Whirl Islands'] = new DungeonTown('Whirl Islands', [new RouteKillRequirement(10, 41), new GymBadgeRequirement(BadgeCase.Badge.Storm)]);
-TownList['Mt Mortar'] = new DungeonTown('Mt Mortar', [new RouteKillRequirement(10, 42), new GymBadgeRequirement(BadgeCase.Badge.Storm)]);
-TownList['Ice Path'] = new DungeonTown('Ice Path', [new RouteKillRequirement(10, 44), new GymBadgeRequirement(BadgeCase.Badge.Glacier)]);
-TownList['Dark Cave'] = new DungeonTown('Dark Cave', [new RouteKillRequirement(10, 45), new GymBadgeRequirement(BadgeCase.Badge.Rising)]);
-TownList['Mt Silver'] = new DungeonTown('Mt Silver', [new RouteKillRequirement(10, 28), new GymBadgeRequirement(BadgeCase.Badge.Elite_Karen)]);
+TownList['Sprout Tower'] = new DungeonTown('Sprout Tower', [new RouteKillRequirement(10, 31)]);
+TownList['Ruins of Alph'] = new DungeonTown('Ruins of Alph', [new RouteKillRequirement(10, 32)]);
+TownList['Union Cave'] = new DungeonTown('Union Cave', [new RouteKillRequirement(10, 32)]);
+TownList['Slowpoke Well'] = new DungeonTown('Slowpoke Well', [new RouteKillRequirement(10, 33)]);
+TownList['Ilex Forest'] = new DungeonTown('Ilex Forest', [new GymBadgeRequirement(BadgeCase.Badge.Hive)]);
+TownList['Burned Tower'] = new DungeonTown('Burned Tower', [new RouteKillRequirement(10, 37)]);
+TownList['Tin Tower'] = new DungeonTown('Tin Tower', [new GymBadgeRequirement(BadgeCase.Badge.Mineral), new GymBadgeRequirement(BadgeCase.Badge.Glacier)]);
+TownList['Whirl Islands'] = new DungeonTown('Whirl Islands', [new GymBadgeRequirement(BadgeCase.Badge.Mineral), new GymBadgeRequirement(BadgeCase.Badge.Glacier)]);
+TownList['Mt Mortar'] = new DungeonTown('Mt Mortar', [new RouteKillRequirement(10, 42)]);
+TownList['Ice Path'] = new DungeonTown('Ice Path', [new RouteKillRequirement(10, 44)]);
+TownList['Dark Cave'] = new DungeonTown('Dark Cave', [new RouteKillRequirement(10, 45)]);
+TownList['Mt Silver'] = new DungeonTown('Mt Silver', [new RouteKillRequirement(10, 28)]);
 
 //Hoenn Shops
 const LittleRootTownShop = new Shop([

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -314,10 +314,7 @@ Routes.add(new RegionRoute(
         land: ['Spearow', 'Rattata', 'Ekans', 'Zubat', 'Hoppip'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [
-        new RouteKillRequirement(10, 32),
-        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Union Cave')),
-    ]
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Union Cave'))]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 34,
@@ -326,11 +323,7 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Tentacruel', 'Krabby', 'Magikarp', 'Staryu', 'Corsola', 'Kingler'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [
-        new RouteKillRequirement(10, 33),
-        new GymBadgeRequirement(BadgeCase.Badge.Hive),
-        new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Union Cave')),
-    ]
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ilex Forest'))]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 35,
@@ -339,7 +332,7 @@ Routes.add(new RegionRoute(
         water: ['Psyduck', 'Golduck', 'Poliwag', 'Magikarp'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Plain)]
+    [new RouteKillRequirement(10, 34)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 36,
@@ -347,7 +340,7 @@ Routes.add(new RegionRoute(
         land: ['Pidgey', 'Nidoran(M)', 'Nidoran(F)', 'Vulpix', 'Growlithe', 'Hoothoot', 'Stantler', 'Sudowoodo'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new RouteKillRequirement(10, 35)]
+    [new GymBadgeRequirement(BadgeCase.Badge.Plain)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 37,
@@ -363,7 +356,7 @@ Routes.add(new RegionRoute(
         land: ['Rattata', 'Raticate', 'Meowth', 'Magnemite', 'Farfetch\'d', 'Tauros', 'Snubbull', 'Miltank'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Fog)]
+    [new RouteKillRequirement(10, 37)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 39,
@@ -378,7 +371,7 @@ Routes.add(new RegionRoute(
     new RoutePokemon({
         water: ['Tentacool', 'Tentacruel', 'Krabby', 'Magikarp', 'Staryu', 'Corsola', 'Kingler'],
     }),
-    [new RouteKillRequirement(10, 39)]
+    [new GymBadgeRequirement(BadgeCase.Badge.Fog)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 41,
@@ -394,7 +387,7 @@ Routes.add(new RegionRoute(
         water: ['Goldeen', 'Seaking', 'Magikarp'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Mineral)]
+    [new GymBadgeRequirement(BadgeCase.Badge.Fog)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 43,
@@ -403,7 +396,7 @@ Routes.add(new RegionRoute(
         water: ['Magikarp', 'Poliwag'],
         headbutt: ['Venonat', 'Exeggcute', 'Hoothoot', 'Pineco'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Glacier)]
+    [new RouteKillRequirement(10, 42)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 44,
@@ -412,7 +405,10 @@ Routes.add(new RegionRoute(
         water: ['Poliwag', 'Poliwhirl', 'Magikarp', 'Remoraid'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Glacier)]
+    [
+        new GymBadgeRequirement(BadgeCase.Badge.Mineral),
+        new GymBadgeRequirement(BadgeCase.Badge.Glacier),
+    ]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 45,
@@ -421,7 +417,7 @@ Routes.add(new RegionRoute(
         water: ['Magikarp', 'Poliwag', 'Dratini'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Rising)]
+    [new ClearDungeonRequirement(1, Statistics.getDungeonIndex('Ice Path'))]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 46,
@@ -429,7 +425,7 @@ Routes.add(new RegionRoute(
         land: ['Spearow', 'Rattata', 'Geodude'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [new RouteKillRequirement(10, 45)]
+    [new RouteKillRequirement(10, 29)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 47,
@@ -438,7 +434,7 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Seel', 'Staryu', 'Magikarp', 'Shellder', 'Chinchou', 'Lanturn'],
         headbutt: ['Metapod', 'Butterfree', 'Kakuna', 'Beedrill', 'Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco', 'Heracross'],
     }),
-    [new GymBadgeRequirement(BadgeCase.Badge.Storm)]
+    [new GymBadgeRequirement(BadgeCase.Badge.Mineral)]
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 48,
@@ -455,7 +451,7 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Tentacruel', 'Magikarp', 'Shellder', 'Chinchou', 'Lanturn'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new RouteKillRequirement(10, 46)],
+    [new RouteKillRequirement(10, 27)],
     49
 ));
 Routes.add(new RegionRoute(
@@ -465,7 +461,7 @@ Routes.add(new RegionRoute(
         water: ['Tentacool', 'Tentacruel', 'Magikarp', 'Shellder', 'Chinchou', 'Lanturn'],
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
-    [new RouteKillRequirement(10, 26)],
+    [new GymBadgeRequirement(BadgeCase.Badge.Rising)],
     50
 ));
 Routes.add(new RegionRoute(

--- a/src/scripts/wildBattle/Routes.ts
+++ b/src/scripts/wildBattle/Routes.ts
@@ -425,7 +425,8 @@ Routes.add(new RegionRoute(
         land: ['Spearow', 'Rattata', 'Geodude'],
         headbutt: ['Spearow', 'Aipom', 'Heracross'],
     }),
-    [new RouteKillRequirement(10, 29)]
+    [new RouteKillRequirement(10, 29)],
+    29.1
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 47,
@@ -452,7 +453,7 @@ Routes.add(new RegionRoute(
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
     [new RouteKillRequirement(10, 27)],
-    49
+    50
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 27,
@@ -462,7 +463,7 @@ Routes.add(new RegionRoute(
         headbutt: ['Exeggcute', 'Hoothoot', 'Ledyba', 'Spinarak', 'Pineco'],
     }),
     [new GymBadgeRequirement(BadgeCase.Badge.Rising)],
-    50
+    49
 ));
 Routes.add(new RegionRoute(
     GameConstants.Region.johto, 28,


### PR DESCRIPTION
Updated the Johto route/gym/dungeon requirements.
Also updated route difficulty.
Swapped route 26 and 27.

List thanks to Ultima:
```json
New Bark Town: none
29: none
46: 29
Cherrygrove City: 29
30: 29
31: 30
Violet City: 31
Sprout Tower: 31
Violet City Gym: Sprout Tower
32: Zephyr Badge
Ruins of Alph: 32
Union Cave: 32
33: Union Cave
Azalea Town: 33
Slowpoke Well: 33
Azalea Town Gym: Slowpoke Well
Ilex Forest: Hive Badge
34: Ilex Forest
Goldenrod City: 34
Goldenrod City Gym: 34
35: 34
36: Plain badge
37: 36
Ecruteak City: 37
Burned Tower: 37
38: 37
39: 38
Olivine City: 39
40: Fog Badge
41: 40
Cianwood City: 41
Olivine City Gym: Storm Badge
47: Mineral Badge
48: 47
42: Fog Badge
Mahogany Town: 42
Mt. Mortar: 42
43: 42
Mahogany Town Gym: 43
44: Mineral Badge & Glacier Badge
Tin Tower: Mineral Badge & Glacier Badge
Whirl Islands: Mineral Badge & Glacier Badge
Ice Path: 44
Blackthorn City: Ice Path
45: Ice Path
Dark Cave: 45
27: Rising Badge
26: 27
Indigo Plateau Johto: 27
28: Champion Lance
Mt. Silver: 28

Route difficulty order: 29, 46, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 47, 48, 27, 26, 28
```