### PR TITLE
[Pokedex] Hide alternate forms that have not yet been caught

### DIFF
--- a/src/scripts/pokedex/PokedexHelper.ts
+++ b/src/scripts/pokedex/PokedexHelper.ts
@@ -96,6 +96,11 @@ class PokedexHelper {
             const alreadyCaught = App.game.party.alreadyCaughtPokemon(pokemon.id);
             const alreadyCaughtShiny = App.game.party.alreadyCaughtPokemon(pokemon.id, true);
 
+            // Alternate forms that we haven't caught yet
+            if (!alreadyCaught && pokemon.id != Math.floor(pokemon.id)) {
+                return false;
+            }
+
             // If not caught
             if (filter['caught'] && !alreadyCaught) {
                 return false;


### PR DESCRIPTION
Only show the alternative forms that have been captured, otherwise just show the shadow for the "main" form

Example with only `A` and `H` `Unown` forms:
![image](https://user-images.githubusercontent.com/7288322/91652256-776af800-eae9-11ea-9335-995c9edcbe86.png)

Example without either `Giritina` forms seen/captured:
![image](https://user-images.githubusercontent.com/7288322/91652282-bc8f2a00-eae9-11ea-9bf3-0870d661d1cb.png)
